### PR TITLE
Update description for buildMessage rawOutput

### DIFF
--- a/addon/utils/validation-errors.js
+++ b/addon/utils/validation-errors.js
@@ -13,13 +13,12 @@ export default function buildMessage(key, result) {
   let returnsRaw = config['changeset-validations']?.rawOutput || false;
   let messages = getMessages();
 
-  let description = messages.getDescriptionFor(key);
-
   if (result.message) {
     return result.message;
   }
 
   let { type, value, context = {} } = result;
+  let description = context?.description ?? messages.getDescriptionFor(key);
 
   let message = get(messages, type);
   if (returnsRaw) {

--- a/tests/unit/utils/validation-errors-test.js
+++ b/tests/unit/utils/validation-errors-test.js
@@ -133,4 +133,30 @@ module('Unit | Utility | validation errors', function () {
     assert.strictEqual(value, d, 'the passed value is returned');
     config['changeset-validations'] = originalConfig; // reset the config
   });
+
+  test('#buildMessage can return a provided description in raw data structure', function (assert) {
+    let originalConfig = config['changeset-validations']; // enable the feature
+    config['changeset-validations'] = { rawOutput: true };
+    let result = buildMessage('firstName', {
+      type: 'present',
+      value: 'testValue',
+      context: { foo: 'foo', description: 'Name' },
+    });
+    assert.notStrictEqual(
+      typeof result,
+      'string',
+      'the return value is an object'
+    );
+    let {
+      message,
+      type,
+      value,
+      context: { description },
+    } = result;
+    assert.ok(message, "{description} can't be blank");
+    assert.strictEqual(description, 'Name', 'description is returned');
+    assert.strictEqual(type, 'present', 'the type of the error is returned');
+    assert.strictEqual(value, 'testValue', 'the passed value is returned');
+    config['changeset-validations'] = originalConfig; // reset the config
+  });
 });


### PR DESCRIPTION
<!--
Thank you for contributing!

Here are a few things that will increase the chance that your pull request will get accepted:
 - Write tests, preferably in a test driven style.
 - Add documentation for the changes you made.
-->

<!-- If this pull request addresses an issue please provide the issue number here -->
Closes #354 .

## Changes proposed in this pull request
<!-- Please describe here what this pull request changes -->

As mentioned in the issue above, the provided description coming from a validation was not passed to the rawOutput in the buildMessage method and always used the key instead. This pull request fixes this.