### PR TITLE
Drop support for Ember.js versions below 4.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,10 +76,6 @@ jobs:
       fail-fast: false
       matrix:
         try-scenario:
-          - ember-lts-3.20
-          - ember-lts-3.24
-          - ember-lts-3.28
-          - ember-lts-4.4
           - ember-lts-4.8
           - ember-lts-4.12
           - ember-lts-5.4

--- a/README.md
+++ b/README.md
@@ -9,15 +9,27 @@
 
 Since `ember-changeset` is required to use this addon, please see [documentation](https://github.com/adopted-ember-addons/ember-changeset/blob/master/README.md) there on how to install and use changesets.
 
-To install if your app is on ember-source >= 3.13:
+## Compatibility
 
-```
+- Ember.js v4.8 or above
+
+## Installation
+
+To install if your app is on ember-source >= 4.8:
+
+```shell
 ember install ember-changeset-validations
+```
+
+To install if your app is on ember-source >= 3.13 < 4.8
+
+```shell
+ember install ember-changeset-validations@4.2.0
 ```
 
 To install if your app is on ember-source < 3.13:
 
-```
+```shell
 ember install ember-changeset-validations@v2.2.1
 ```
 

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
   },
   "peerDependencies": {
     "@ember/string": "^3.0.0 || ^4.0.0",
-    "ember-source": ">= 3.20.0"
+    "ember-source": ">= 4.8.0"
   },
   "packageManager": "pnpm@10.7.0",
   "pnpm": {

--- a/tests/dummy/config/ember-try.js
+++ b/tests/dummy/config/ember-try.js
@@ -8,55 +8,6 @@ module.exports = async function () {
     usePnpm: true,
     scenarios: [
       {
-        name: 'ember-lts-3.20',
-        npm: {
-          devDependencies: {
-            '@ember/test-helpers': '^2.9.3',
-            'ember-cli': '~4.12.3',
-            'ember-load-initializers': '^2.0.0',
-            'ember-qunit': '^5.1.5',
-            'ember-resolver': '^8.0.0',
-            'ember-source': '~3.20.5',
-          },
-        },
-      },
-      {
-        name: 'ember-lts-3.24',
-        npm: {
-          devDependencies: {
-            '@ember/test-helpers': '^2.9.3',
-            'ember-cli': '~4.12.3',
-            'ember-load-initializers': '^2.0.0',
-            'ember-qunit': '^5.1.5',
-            'ember-resolver': '^8.0.0',
-            'ember-source': '~3.24.3',
-          },
-        },
-      },
-      {
-        name: 'ember-lts-3.28',
-        npm: {
-          devDependencies: {
-            '@ember/test-helpers': '^2.9.3',
-            'ember-cli': '~4.12.3',
-            'ember-load-initializers': '^2.0.0',
-            'ember-qunit': '^6.2.0',
-            'ember-resolver': '^8.0.0',
-            'ember-source': '~3.28.4',
-          },
-        },
-      },
-      {
-        name: 'ember-lts-4.4',
-        npm: {
-          devDependencies: {
-            'ember-load-initializers': '^2.0.0',
-            'ember-resolver': '^8.0.0',
-            'ember-source': '~4.4.0',
-          },
-        },
-      },
-      {
         name: 'ember-lts-4.8',
         npm: {
           devDependencies: {


### PR DESCRIPTION
This simplifies CI setup and support for Embroider/Vite moving forward.

Currently Ember.js v6.3 is the latest version, so it's still two old major versions.

As addon is pretty simple, there is high chance it would work even with older versions if needed.