### PR TITLE
Update used description for buildMessage rawOutput

### DIFF
--- a/src/utils/validation-errors.js
+++ b/src/utils/validation-errors.js
@@ -21,6 +21,10 @@ export default function buildMessage(key, result) {
 
   let { type, value, context = {} } = result;
 
+  if (context?.description) {
+    description = context.description;
+  }
+
   let message = get(messages, type);
   if (returnsRaw) {
     context = Object.assign({}, context, { description });

--- a/test-app-raw-output/tests/unit/utils/validation-errors-test.js
+++ b/test-app-raw-output/tests/unit/utils/validation-errors-test.js
@@ -49,5 +49,31 @@ module('Unit | Utility | validation errors', function () {
       assert.strictEqual(type, 'date', 'the type of the error is returned');
       assert.strictEqual(value, d, 'the passed value is returned');
     });
+
+    test('#buildMessage can return a provided description in raw data structure', function (assert) {
+      let result = buildMessage('firstName', {
+        type: 'present',
+        value: 'testValue',
+        context: { foo: 'foo', description: 'Name' },
+      });
+
+      assert.notStrictEqual(
+        typeof result,
+        'string',
+        'the return value is an object',
+      );
+
+      let {
+        message,
+        type,
+        value,
+        context: { description },
+      } = result;
+
+      assert.ok(message, "{description} can't be blank");
+      assert.strictEqual(description, 'Name', 'description is returned');
+      assert.strictEqual(type, 'present', 'the type of the error is returned');
+      assert.strictEqual(value, 'testValue', 'the passed value is returned');
+    });
   });
 });


### PR DESCRIPTION
<!--
Thank you for contributing!

Here are a few things that will increase the chance that your pull request will get accepted:
 - Write tests, preferably in a test driven style.
 - Add documentation for the changes you made.
-->

<!-- If this pull request addresses an issue please provide the issue number here -->
Closes #354 .

## Changes proposed in this pull request
<!-- Please describe here what this pull request changes -->

As mentioned in the issue above, the provided description coming from a validation was not passed to the rawOutput in the buildMessage method. It always used the key instead. The changes are needed for better internationalization. This pull request fixes this.